### PR TITLE
Don't import bleak when on CI.

### DIFF
--- a/_bleio.py
+++ b/_bleio.py
@@ -40,7 +40,7 @@ import time
 if "GITHUB_ACTION" not in os.environ:
     import bleak
 else:
-    bleak = None # pylint: disable=invalid-name
+    bleak = None  # pylint: disable=invalid-name
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_bleio.git"

--- a/_bleio.py
+++ b/_bleio.py
@@ -31,10 +31,16 @@
 """
 
 import asyncio
+import os
 import struct
 import time
 
-import bleak
+# Don't import bleak is we're running in the CI. We could mock it out but that
+# would require mocking in all reverse dependencies.
+if "GITHUB_ACTION" not in os.environ:
+    import bleak
+else:
+    bleak = None
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_bleio.git"

--- a/_bleio.py
+++ b/_bleio.py
@@ -40,7 +40,7 @@ import time
 if "GITHUB_ACTION" not in os.environ:
     import bleak
 else:
-    bleak = None
+    bleak = None # pylint: disable=invalid-name
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_bleio.git"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,11 +17,9 @@ extensions = [
     "sphinx.ext.todo",
 ]
 
-# TODO: Please Read!
-# Uncomment the below if you use native CircuitPython modules such as
-# digitalio, micropython and busio. List the modules you use. Without it, the
-# autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["bleak"]
+# Uncomment this mock below if you are manually testing the sphinx build on a
+# system where bleak isn't supported.
+# autodoc_mock_imports = ["bleak"]
 
 
 intersphinx_mapping = {


### PR DESCRIPTION
Mocking it only helps with this repo's CI. Reverse dependencies
would still need to know to mock bleak as well. By not importing it,
we don't require special treatment from reverse dependencies.