### PR TITLE
Add standard _bleio exceptions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,9 @@ jobs:
         pip install --force-reinstall pylint black==19.10b0 Sphinx sphinx-rtd-theme
     - name: Library version
       run: git describe --dirty --always --tags
+    - name: Check formatting
+      run: |
+        black --check --target-version=py35 .
     - name: PyLint
       run: |
         pylint $( find . -path './_bleio*.py' )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,14 +34,15 @@ jobs:
       with:
         repository: adafruit/actions-ci-circuitpython-libs
         path: actions-ci
-    - name: Install deps
+    - name: Install dependencies
+      # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
       run: |
         source actions-ci/install.sh
+    - name: Pip install pylint, black, & Sphinx
+      run: |
+        pip install --force-reinstall pylint black==19.10b0 Sphinx sphinx-rtd-theme
     - name: Library version
       run: git describe --dirty --always --tags
-    - name: Check formatting
-      run: |
-        black --check --target-version=py35 .
     - name: PyLint
       run: |
         pylint $( find . -path './_bleio*.py' )

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Permissions
 =============
 
 For comprehensive scanning we use ``hcidump`` and ``hcitool``. By default, only root has
-enough privileges though.
+enough privileges to do what we need.
 
 So, to get permissions we use capabilities to grant ``hcitool`` and ``hcidump`` raw network
 access. This is very powerful! So, to limit access we change file execution permissions to
@@ -103,4 +103,3 @@ Raspberry Pi 3b Rev 1.2
 The Raspberry Pi 3b's BLE chip is connected over UART to the main processor without flow control.
 This can cause unreliability with BLE. To improve reliability, we can slow the UART. To do so,
 edit ``/usr/bin/btuart`` and replace the ``921600`` with ``460800``.
-

--- a/_bleio.py
+++ b/_bleio.py
@@ -52,6 +52,26 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_bleio.git"
 
 
+class BluetoothError(Exception):
+    """Catch-all exception for Bluetooth related errors."""
+
+
+class ConnectionError(BluetoothError):  # pylint: disable=redefined-builtin
+    """Raised when a connection is unavailable."""
+
+
+class RoleError(BluetoothError):
+    """
+    Raised when a resource is used in a mismatched role. For example,
+    will be raised if you attempt to set a local CCCD
+    that can only be set when remote.
+    """
+
+
+class SecurityError(BluetoothError):
+    """Raised when a security related error occurs."""
+
+
 class Address:
     """Create a new Address object encapsulating the address value."""
 


### PR DESCRIPTION
Add standard `_bleio` exceptions that are used in CircuitPython, so that we can use these in other Python code and have them known to pylint and sphinx.

This PR does _not_ add any code that translates HCI errors into exceptions. It would be good to add that.