### PR TITLE
Add device name to advertisement data that is passed back.

### DIFF
--- a/_bleio/scan_entry.py
+++ b/_bleio/scan_entry.py
@@ -36,12 +36,18 @@ from _bleio import Address, UUID
 Buf = Union[bytes, bytearray, memoryview]
 
 
-
 class ScanEntry:
+    # Some device names are created by the bleak code or what it calls, and aren't the
+    # real advertised name. Suppress those. Patterns seen include (XX are hex digits):
+    # dev_XX_XX_XX_XX_XX_XX
+    # XX-XX-XX-XX-XX-XX
+    # Unknown
     _RE_IGNORABLE_NAME = re.compile(
-        r"[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}",
-        re.IGNORECASE
-        )
+        r"((dev_)?"
+        r"[0-9A-F]{2}[-_][0-9A-F]{2}[-_][0-9A-F]{2}[-_][0-9A-F]{2}[-_][0-9A-F]{2}[-_][0-9A-F]{2})"
+        r"|Unknown",
+        re.IGNORECASE,
+    )
 
     def __init__(
         self,
@@ -182,7 +188,7 @@ class ScanEntry:
 
         if not cls._RE_IGNORABLE_NAME.fullmatch(device.name):
             # Complete name
-            data_dict[0x09] = device.name.encode('utf-8')
+            data_dict[0x09] = device.name.encode("utf-8")
 
         return data_dict
 

--- a/_bleio/scan_entry.py
+++ b/_bleio/scan_entry.py
@@ -156,8 +156,8 @@ class ScanEntry:
             bytes((data_type,)) + data for data_type, data in self._data_dict.items()
         )
 
-    @classmethod
-    def _data_dict_from_bleak(cls, device):
+    @staticmethod
+    def _data_dict_from_bleak(device):
         data_dict = {}
         for key, value in device.metadata.items():
             if key == "manufacturer_data":
@@ -186,7 +186,7 @@ class ScanEntry:
                 # Complete list of 128-bit UUIDs
                 data_dict[0x07] = uuids128
 
-        if not cls._RE_IGNORABLE_NAME.fullmatch(device.name):
+        if not ScanEntry._RE_IGNORABLE_NAME.fullmatch(device.name):
             # Complete name
             data_dict[0x09] = device.name.encode("utf-8")
 


### PR DESCRIPTION
The device name was omitted from the synthetic advertisement data created from ScanEntry objects. We need the name to recognize some devices, such as BerryMed pulse oximeters.

In some cases an artificial name, either "Unknown" or a human-readable hex address, is passed back from bleak or the libraries that bleak calls.  Find these and discard them.