### PR TITLE
add set_adapter(); fix new pylint complaints

### DIFF
--- a/_bleio/__init__.py
+++ b/_bleio/__init__.py
@@ -30,6 +30,8 @@ _bleio implementation for Adafruit_Blinka_bleio
 
 # pylint: disable=wrong-import-position
 
+from typing import Optional
+
 # These are in dependency order to avoid circular import issues.
 
 from _bleio.exceptions import *  # pylint: disable=redefined-builtin
@@ -45,6 +47,14 @@ from _bleio.scan_entry import *
 
 from _bleio.characteristic_buffer import *
 from _bleio.packet_buffer import *
+
+
+def set_adapter(new_adapter: Optional[Adapter]) -> None:
+    """Set the adapter to use for BLE, such as when using an HCI adapter.
+    Raises `NotImplementedError` when the adapter is a singleton and cannot be set.
+    """
+    raise NotImplementedError("Not settable")
+
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_Blinka_bleio.git"

--- a/_bleio/adapter_.py
+++ b/_bleio/adapter_.py
@@ -49,7 +49,7 @@ if platform.system() == "Linux":
 
 Buf = Union[bytes, bytearray, memoryview]
 
-# Singleton _bleio.adapter is defined at the ned of this file.
+# Singleton _bleio.adapter is defined at the end of this file.
 adapter = None  # pylint: disable=invalid-name
 
 
@@ -345,7 +345,7 @@ class Adapter:
             # This does not seem to connect reliably.
             # await asyncio.wait_for(client.connect(), timeout)
         except asyncio.TimeoutError:
-            raise BluetoothError("Failed to connect: timeout")
+            raise BluetoothError("Failed to connect: timeout") from asyncio.TimeoutError
 
         connection = Connection._from_bleak(address, client)
         self._connections.append(connection)

--- a/_bleio/characteristic.py
+++ b/_bleio/characteristic.py
@@ -73,7 +73,7 @@ class Characteristic:
         """There is no regular constructor for a Characteristic.  A
         new local Characteristic can be created and attached to a
         Service by calling `add_to_service()`.  Remote Characteristic
-        objects are created by `Connection.discover_remote_services()`
+        objects are created by `_bleio.Connection.discover_remote_services`
         as part of remote Services."""
         self._uuid = uuid
         self._properties = properties

--- a/_bleio/connection.py
+++ b/_bleio/connection.py
@@ -64,9 +64,9 @@ class Connection:
 
     def __init__(self, address: _bleio.address.Address):
         """Connections should not be created directly.
-        Instead, to initiate a connection use `Adapter.connect`.
+        Instead, to initiate a connection use `_bleio.Adapter.connect`.
         Connections may also be made when another device initiates a connection. To use a Connection
-        created by a peer, read the `Adapter.connections` property.
+        created by a peer, read the `_bleio.Adapter.connections` property.
 
         :param _bleio.address.Address address: _bleio.address.Address of device to connect to
         """

--- a/_bleio/descriptor.py
+++ b/_bleio/descriptor.py
@@ -59,7 +59,7 @@ class Descriptor:
 
         """There is no regular constructor for a Descriptor. A new local Descriptor can be created
         and attached to a Characteristic by calling `add_to_characteristic()`.
-        Remote Descriptor objects are created by `Connection.discover_remote_services()`
+        Remote Descriptor objects are created by `_bleio.Connection.discover_remote_services`
         as part of remote Characteristics in the remote Services that are discovered.
         """
         self._uuid = uuid

--- a/_bleio/service.py
+++ b/_bleio/service.py
@@ -45,7 +45,7 @@ class Service:
     ):
         """Create a new Service identified by the specified UUID. It can be accessed by all
         connections. This is known as a Service server. Client Service objects are created via
-        `Connection.discover_remote_services`.
+        `_bleio.Connection.discover_remote_services`.
 
         To mark the Service as secondary, pass `True` as :py:data:`secondary`.
 

--- a/_bleio/uuid_.py
+++ b/_bleio/uuid_.py
@@ -94,7 +94,9 @@ class UUID:
             try:
                 uuid = memoryview(uuid)
             except TypeError:
-                raise ValueError("UUID value is not str, int or byte buffer")
+                raise ValueError(
+                    "UUID value is not str, int or byte buffer"
+                ) from TypeError
             if len(uuid) != 16:
                 raise ValueError("Byte buffer must be 16 bytes")
             self._size = 128

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,8 @@ extensions = [
 # system where bleak isn't supported.
 autodoc_mock_imports = ["bleak"]
 
+# Show the docstring from both the class and its __init__() method
+autoclass_content = "both"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.4", None),


### PR DESCRIPTION
`_bleio.set_adapter()` is new in CircuitPython 6.0.0. Add a not-implemented version here for consistency.

Fix some new pylint complaints due to upgrading pylint.

Add including `__init__()` docstrings to generated doc (see https://github.com/adafruit/cookiecutter-adafruit-circuitpython/issues/86).