### PR TITLE
Fixed FileNotFound and permissions exceptions on RasPi

### DIFF
--- a/_bleio/adapter_.py
+++ b/_bleio/adapter_.py
@@ -94,7 +94,7 @@ class Adapter:
                     )
                     # Succeeded.
                     self._hcitool_is_usable = True
-                except subprocess.SubprocessError:
+                except:
                     # Lots of things can go wrong:
                     # no hcitool, no privileges (causes non-zero return code), too slow, etc.
                     pass

--- a/_bleio/adapter_.py
+++ b/_bleio/adapter_.py
@@ -114,7 +114,7 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
                     )
                     # Succeeded.
                     self._hcitool_is_usable = True
-                except (subprocess.SubprocessError, FileNotFoundError):
+                except (subprocess.SubprocessError, FileNotFoundError, PermissionError):
                     # Lots of things can go wrong:
                     # no hcitool, no privileges (causes non-zero return code), too slow, etc.
                     pass

--- a/_bleio/adapter_.py
+++ b/_bleio/adapter_.py
@@ -114,7 +114,7 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
                     )
                     # Succeeded.
                     self._hcitool_is_usable = True
-                except:
+                except (subprocess.SubprocessError, FileNotFoundError):
                     # Lots of things can go wrong:
                     # no hcitool, no privileges (causes non-zero return code), too slow, etc.
                     pass


### PR DESCRIPTION
I'll admit I'm not SUUUUPER sure what's exactly going on here, but in light of (98) "Lots of things can go wrong:" I agree and it seems `subprocess.SubprocessError` is too restrictive.

I'm testing on Raspberry Pi (actually, my bad on the commit message, I'm confusing myself), and trying to go back and forth between using `hcitool` and not. For whatever reason, before I ever installed hcitool, I had no problems at all and the library worked without failure. Since installing hcitool and trying to disable it either by renaming or removing my user from the bluetooth group, I get either FileNotFoundException or a permissions exception, respectively. Both of these, being not equal to `subprocess.SubprocessError` crash the main script.

Generically catching all exceptions here fixes all of the exception type ambiguity and I think satisfies the spirit of the code without introducing edge cases? Though I'd like to understand better why it works just fine out of the box, and only breaks when I re-disable hcitool.