### PR TITLE
Readline fix; bleak update

### DIFF
--- a/_bleio/characteristic_buffer.py
+++ b/_bleio/characteristic_buffer.py
@@ -127,6 +127,7 @@ class CharacteristicBuffer:
             except queue.Empty:
                 # Let the BLE code run for a bit, and try again.
                 adap.adapter.await_bleak(asyncio.sleep(0.1))
+                continue
             if b == 0x0A:  # newline
                 break
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Adafruit-Blinka
-bleak>=0.8.0
+bleak>=0.9.1


### PR DESCRIPTION
Nordic UART readline was buggy if no input.
bleak >= 0.9.1 needed for various fixes, especially MacOS.