### PR TITLE
Add missing args to (not implemented) Adapter.start_advertising()

### DIFF
--- a/_bleio/adapter_.py
+++ b/_bleio/adapter_.py
@@ -175,6 +175,8 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
         *,
         scan_response: Buf = None,
         connectable: bool = True,
+        anonymous: bool = False,
+        timeout: int = 0,
         interval: float = 0.1,
     ) -> None:
         raise NotImplementedError("Advertising not implemented")


### PR DESCRIPTION
`Adapter.start_advertising()` is missing some parameters. Even though it's not implemented, the missing parameters can cause confusing errors.

Fixes #25.