### PR TITLE
Add readme note about disabling hcitool backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,8 +90,8 @@ behavior, you can do the following:
 .. code-block:: python
 
     ble = BLERadio()
-    ble._adapter.BLE_BACKEND = "bleak" # Forces bleak even if hcitool works.
-    # ble._adapter.BLE_BACKEND = "hcitool" # Forces hcitool. Raises exception if unavailable.
+    ble._adapter.ble_backend = "bleak" # Forces bleak even if hcitool works.
+    # ble._adapter.ble_backend = "hcitool" # Forces hcitool. Raises exception if unavailable.
 
 To add yourself to the ``bluetooth`` group do:
 

--- a/README.rst
+++ b/README.rst
@@ -84,13 +84,14 @@ not need to add these permissions. This library falls back to using**
 ``bleak`` **for regular scanning if** ``hcitool`` **does not have
 these extra permissions.**
 
-If you **explicitly** want to disable hcitool i.e. for testing, you can
-do something like this:
+If you **explicitly** want to choose the backend to ensure consistent
+behavior, you can do the following:
 
 .. code-block:: python
 
     ble = BLERadio()
-    ble._adapter._hcitool_is_usable = False # Forces bleak even if hcitool works.
+    ble._adapter.BLE_BACKEND = "bleak" # Forces bleak even if hcitool works.
+    # ble._adapter.BLE_BACKEND = "hcitool" # Forces hcitool. Raises exception if unavailable.
 
 To add yourself to the ``bluetooth`` group do:
 

--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,7 @@ If you **explicitly** want to disable hcitool i.e. for testing, you can
 do something like this:
 
 .. code-block:: python
+
     ble = BLERadio()
     ble._adapter._hcitool_is_usable = False # Forces bleak even if hcitool works.
 

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,13 @@ not need to add these permissions. This library falls back to using**
 ``bleak`` **for regular scanning if** ``hcitool`` **does not have
 these extra permissions.**
 
+If you **explicitly** want to disable hcitool i.e. for testing, you can
+do something like this:
+
+.. code-block:: python
+    ble = BLERadio()
+    ble._adapter._hcitool_is_usable = False # Forces bleak even if hcitool works.
+
 To add yourself to the ``bluetooth`` group do:
 
 .. code-block:: shell

--- a/_bleio/adapter_.py
+++ b/_bleio/adapter_.py
@@ -80,6 +80,7 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
         # Not known yet.
         self._hcitool_is_usable = None
         self._hcitool = None
+        self.BLE_BACKEND = None
 
         # Keep a cache of recently scanned devices, to avoid doing double
         # device scanning.
@@ -99,6 +100,9 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
 
     @property
     def _use_hcitool(self):
+        """ Determines whether to use the hcitool backend or default bleak, based on whether
+        we want to and can use hcitool.
+        """
         if self._hcitool_is_usable is None:
             self._hcitool_is_usable = False
             if platform.system() == "Linux":
@@ -118,6 +122,16 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
                     # Lots of things can go wrong:
                     # no hcitool, no privileges (causes non-zero return code), too slow, etc.
                     pass
+            if self.BLE_BACKEND:
+                if self.BLE_BACKEND == "bleak":
+                    # User requests bleak, so ignore hcitool.
+                    self._hcitool_is_usable = False
+                elif self.BLE_BACKEND == "hcitool":
+                    if not self._hcitool_is_usable:
+                        # User wants hcitool, but it's not working. Raise an exception.
+                        raise EnvironmentError("BLE_BACKEND set to 'hcitool', but hcitool is unavailable")
+                else:
+                    raise ValueError("BLE_BACKEND setting not recognized. Should be 'hcitool' or 'bleak'.")
 
         return self._hcitool_is_usable
 

--- a/_bleio/adapter_.py
+++ b/_bleio/adapter_.py
@@ -100,7 +100,7 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
 
     @property
     def _use_hcitool(self):
-        """ Determines whether to use the hcitool backend or default bleak, based on whether
+        """Determines whether to use the hcitool backend or default bleak, based on whether
         we want to and can use hcitool.
         """
         if self._hcitool_is_usable is None:
@@ -129,9 +129,13 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
                 elif self.BLE_BACKEND == "hcitool":
                     if not self._hcitool_is_usable:
                         # User wants hcitool, but it's not working. Raise an exception.
-                        raise EnvironmentError("BLE_BACKEND set to 'hcitool', but hcitool is unavailable")
+                        raise EnvironmentError(
+                            "BLE_BACKEND set to 'hcitool', but hcitool is unavailable"
+                        )
                 else:
-                    raise ValueError("BLE_BACKEND setting not recognized. Should be 'hcitool' or 'bleak'.")
+                    raise ValueError(
+                        "BLE_BACKEND setting not recognized. Should be 'hcitool' or 'bleak'."
+                    )
 
         return self._hcitool_is_usable
 

--- a/_bleio/adapter_.py
+++ b/_bleio/adapter_.py
@@ -80,7 +80,7 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
         # Not known yet.
         self._hcitool_is_usable = None
         self._hcitool = None
-        self.BLE_BACKEND = None
+        self.ble_backend = None
 
         # Keep a cache of recently scanned devices, to avoid doing double
         # device scanning.
@@ -122,19 +122,19 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
                     # Lots of things can go wrong:
                     # no hcitool, no privileges (causes non-zero return code), too slow, etc.
                     pass
-            if self.BLE_BACKEND:
-                if self.BLE_BACKEND == "bleak":
+            if self.ble_backend:
+                if self.ble_backend == "bleak":
                     # User requests bleak, so ignore hcitool.
                     self._hcitool_is_usable = False
-                elif self.BLE_BACKEND == "hcitool":
+                elif self.ble_backend == "hcitool":
                     if not self._hcitool_is_usable:
                         # User wants hcitool, but it's not working. Raise an exception.
                         raise EnvironmentError(
-                            "BLE_BACKEND set to 'hcitool', but hcitool is unavailable"
+                            "ble_backend set to 'hcitool', but hcitool is unavailable"
                         )
                 else:
                     raise ValueError(
-                        "BLE_BACKEND setting not recognized. Should be 'hcitool' or 'bleak'."
+                        "ble_backend setting not recognized. Should be 'hcitool' or 'bleak'."
                     )
 
         return self._hcitool_is_usable


### PR DESCRIPTION
Fixes #19, kind of. There's no even kind of clean way to make a proper API for switching manually between the bleak and hcitool backends, so for now I've just made a note in the readme.