### PR TITLE
Update characteristic.py

### DIFF
--- a/_bleio/characteristic.py
+++ b/_bleio/characteristic.py
@@ -225,7 +225,7 @@ class Characteristic:
             )
         else:
             adap.adapter.await_bleak(
-                self._service._bleak_client.stop_notify(
+                self._service.connection._bleak_client.stop_notify(
                     self._bleak_gatt_characteristic.uuid
                 )
             )


### PR DESCRIPTION
Added missing 'connection' member to `stop_notify` method call.

fixes this crash: 
```
  File /lib/python3.7/site-packages/_bleio/characteristic.py", line 228, in set_cccd
    self._service._bleak_client.stop_notify(
AttributeError: 'Service' object has no attribute '_bleak_client'
```