### PR TITLE
Fix properties check to use Bleak Write value

### DIFF
--- a/_bleio/common.py
+++ b/_bleio/common.py
@@ -578,7 +578,7 @@ class Characteristic:
             self.service.connection._bleak_client.write_gatt_char(
                 self.uuid._bleak_uuid,
                 bytearray(val),
-                response=self.properties & Characteristic.WRITE,
+                response=self.properties & GattCharacteristicsFlags["write"].value,
             )
         )
 


### PR DESCRIPTION
Re: Issue #39 Unable to Write Characteristic

I have tested this change on Windows 10

Let me know if there is anything I missed.

Thanks,
Phil