### PR TITLE
Switch to use discovered devices property

### DIFF
--- a/_bleio/common.py
+++ b/_bleio/common.py
@@ -359,7 +359,7 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
         await self._scanner.start()
         await asyncio.sleep(interval)
         await self._scanner.stop()
-        return await self._scanner.get_discovered_devices()
+        return self._scanner.discovered_devices
 
     def stop_scan(self) -> None:
         """Stop scanning before timeout may have occurred."""


### PR DESCRIPTION
Resolves #41 by switching to `discovered_devices` property.  Did not test, but it seems like `get_discovered _devices()` was just calling that anyways