### PR TITLE
hcitool backend: poll on hcidump (not hcitool)

### DIFF
--- a/_bleio/common.py
+++ b/_bleio/common.py
@@ -334,7 +334,7 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
         # Throw away the first two output lines of hcidump because they are version info.
         hcidump.stdout.readline()  # type: ignore[union-attr]
         hcidump.stdout.readline()  # type: ignore[union-attr]
-        returncode = self._hcitool.poll()
+        returncode = hcidump.poll()
         start_time = time.monotonic()
         buffered: List[bytes] = []
         while returncode is None and (
@@ -351,7 +351,7 @@ class Adapter:  # pylint: disable=too-many-instance-attributes
                         yield parsed
                     buffered.clear()
             buffered.append(line)
-            returncode = self._hcitool.poll()
+            returncode = hcidump.poll()
         self.stop_scan()
 
     async def _scan_for_interval(self, interval: float) -> Iterable[ScanEntry]:


### PR DESCRIPTION
The _start_scan_hcitool() loop should poll on the hcidump subprocess, not the hcitool subprocess.  The hcitool command doesn't work on BlueZ 5 so it immediately fails.  It may still be needed on Bluez 4.  The main loop should continue as long as hcidump is still running and ignore the status of hcitool.