### PR TITLE
support bleak 0.19.0 and up

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,6 @@ jobs:
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
-    - name: Build assets
-      run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
-    - name: Archive bundles
-      uses: actions/upload-artifact@v3
-      with:
-        name: bundles
-        path: ${{ github.workspace }}/bundles/
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html
@@ -70,7 +63,7 @@ jobs:
       if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
       run: |
         pip install --upgrade build twine
-        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
+        for file in $(find -type f -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
             sed -i -e "s/0.0.0+auto.0/1.2.3/" $file;
         done;
         python -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
     "wheel",
     "setuptools-scm",
 ]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "adafruit-blinka-bleio"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@
 # SPDX-License-Identifier: MIT
 
 Adafruit-Blinka
-# Pin bleak version because its API is still somewhat in flux.
-bleak==0.11.0
+bleak


### PR DESCRIPTION
The `bleak` version was pinned to 0.11.0 in the early days of this library, when `bleak` was undergoing a lot of API churn.  That may have also prevented advancing the supported Python version (the guide recommended Python 3.8). There have been many changes, fixes, and improvements to `bleak` since then. As an example, the Windows backend now uses a different lower-level lirbrary.

Updated to handle API changes in `bleak` from 0.19.0 on. 

Tested using `adafruit_ble_heart_rate` with `bleak` 0.20.1, on Linux, macoS 13.2.1 and 13.3, Windows 10, and Windows 11, with Python 3.10.x and 3.11.x. Works on all, except that on Windows, the default timeout for `BLERadio.connect()`, which is 4 seconds seems to be too short at least some of the time. I increased it to 10 seconds and it connects successfully. Once it has connected once, further connects are faster. I may change the timeout there after this is released; at the very least I will document the issue in the Learn Guide, https://learn.adafruit.com/circuitpython-ble-libraries-on-any-computer.

EDIT: Tested on latest RPI bullseye as well. Works, after lengthening connection timeout to 10 seconds, as I had to do for Windows. This confirms it's a good idea to change the default.

Fixes #41.
Fixes #45.