### PR TITLE
Fixed CharacteristicBuffer read function to handle timeouts.

### DIFF
--- a/_bleio/characteristic_buffer.py
+++ b/_bleio/characteristic_buffer.py
@@ -72,9 +72,10 @@ class CharacteristicBuffer:
         buffer = bytearray(
             min(nbytes, self._buffer_size) if nbytes else self._buffer_size
         )
-        if self.readinto(buffer) == 0:
+        bytes_read = self.readinto(buffer)
+        if bytes_read == 0:
             return None
-        return buffer
+        return buffer[:bytes_read]
 
     def readinto(self, buf: Buf) -> Union[int, None]:
         """Read bytes into the ``buf``. Read at most ``len(buf)`` bytes.


### PR DESCRIPTION
In the event of a connection timeout the read method will return a buffer with some data up front, zeros padding the end, and no indication of how many bytes were actually read. There's no way to distinguish between zeros padding the data and zeros occurring immediately before the timeout.

This fixes the problem by only returning a buffer the size of the data that was read.

Fixes #59 