### PR TITLE
Added 32-bit UUID support.

### DIFF
--- a/_bleio/scan_entry.py
+++ b/_bleio/scan_entry.py
@@ -164,18 +164,27 @@ class ScanEntry:
 
         if uuids := advertisement_data.service_uuids:
             uuids16 = bytearray()
+            uuids32 = bytearray()
             uuids128 = bytearray()
             for uuid in uuids:
                 bleio_uuid = UUID(uuid)
-                # If this is a Standard UUID in 128-bit form, convert it to a 16-bit UUID.
+                # If this is a Standard UUID in 128-bit form, convert it to a 16- or 32-bit UUID.
                 if bleio_uuid.is_standard_uuid:
-                    uuids16.extend(bleio_uuid.uuid128[12:14])
+                    if bleio_uuid.size == 16:
+                        uuids16.extend(bleio_uuid.uuid128[12:14])
+                    elif bleio_uuid.size == 32:
+                        uuids32.extend(bleio_uuid.uuid128[12:16])
+                    else:
+                        raise RuntimeError("Unexpected UUID size")
                 else:
                     uuids128.extend(bleio_uuid.uuid128)
 
             if uuids16:
                 # Complete list of 16-bit UUIDs.
                 data_dict[0x03] = uuids16
+            if uuids32:
+                # Complete list of 32-bit UUIDs.
+                data_dict[0x05] = uuids32
             if uuids128:
                 # Complete list of 128-bit UUIDs
                 data_dict[0x07] = uuids128

--- a/_bleio/uuid_.py
+++ b/_bleio/uuid_.py
@@ -25,11 +25,15 @@ _UUID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", flags=re.IGNORECASE
 )
 
-_STANDARD_UUID_RE = re.compile(
+_STANDARD_UUID_RE_16 = re.compile(
     r"0000....-0000-1000-8000-00805f9b34fb", flags=re.IGNORECASE
 )
 
-_STANDARD_HEX_UUID_RE = re.compile(r"[0-9a-f]{1,4}", flags=re.IGNORECASE)
+_STANDARD_UUID_RE_32 = re.compile(
+    r"........-0000-1000-8000-00805f9b34fb", flags=re.IGNORECASE
+)
+
+_STANDARD_HEX_UUID_RE = re.compile(r"[0-9a-f]{1,8}", flags=re.IGNORECASE)
 
 _BASE_STANDARD_UUID = (
     b"\xFB\x34\x9B\x5F\x80\x00\x00\x80\x00\x10\x00\x00\x00\x00\x00\x00"
@@ -37,53 +41,55 @@ _BASE_STANDARD_UUID = (
 
 
 class UUID:
+    @staticmethod
+    def standard_uuid128_from_uuid32(uuid32: int) -> bytes:
+        """Return a 128-bit standard UUID from a 32-bit standard UUID."""
+        if not 0 <= uuid32 < 2 ** 32:
+            raise ValueError("UUID integer value must be unsigned 32-bit")
+        return _BASE_STANDARD_UUID[:-4] + uuid32.to_bytes(4, "little")
+
     def __init__(self, uuid: Union[int, Buf, str]):
         self.__bleak_uuid = None
 
         if isinstance(uuid, str):
             if _UUID_RE.fullmatch(uuid):
-                self._size = 16 if _STANDARD_UUID_RE.fullmatch(uuid) else 128
-                uuid = uuid.replace("-", "")
-                self._uuid128 = bytes(
-                    int(uuid[i : i + 2], 16) for i in range(30, -1, -2)
-                )
-                return
+                # Pick the smallest standard size.
+                if _STANDARD_UUID_RE_16.fullmatch(uuid):
+                    self._size = 16
+                    uuid16 = int(uuid[4:8], 16)
+                    self._uuid128 = self.standard_uuid128_from_uuid32(uuid16)
+                elif _STANDARD_UUID_RE_32.fullmatch(uuid):
+                    self._size = 32
+                    uuid32 = int(uuid[0:8], 16)
+                    self._uuid128 = self.standard_uuid128_from_uuid32(uuid32)
+                else:
+                    self._size = 128
+                    uuid = uuid.replace("-", "")
+                    self._uuid128 = bytes(
+                        int(uuid[i : i + 2], 16) for i in range(30, -1, -2)
+                    )
 
-            if _STANDARD_HEX_UUID_RE.fullmatch(uuid):
+            elif _STANDARD_HEX_UUID_RE.fullmatch(uuid) and len(uuid) in (4, 8):
                 # Fall through and reprocess as an int.
-                uuid = int(uuid, 16)
+                uuid_int = int(uuid, 16)
+                self._size = len(uuid)*4 # 4 bits per hex digit
+                self._uuid128 = self.standard_uuid128_from_uuid32(uuid_int)
+
             else:
                 raise ValueError(
-                    "UUID string not 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' or 'xxxx', but is "
+                    "UUID string not 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', 'xxxx', or 'xxxxxxxx', but is "
                     + uuid
                 )
 
-        if isinstance(uuid, int):
-            if not 0 <= uuid <= 0xFFFF:
-                raise ValueError("UUID integer value must be 0-0xffff")
-            self._size = 16
-            self._uuid16 = uuid
-            # Put into "0000xxxx-0000-1000-8000-00805F9B34FB"
-            self._uuid128 = bytes(
-                (
-                    0xFB,
-                    0x34,
-                    0x9B,
-                    0x5F,
-                    0x80,
-                    0x00,  # 00805F9B34FB
-                    0x00,
-                    0x80,  # 8000
-                    0x00,
-                    0x10,  # 1000
-                    0x00,
-                    0x00,  # 0000
-                    uuid & 0xFF,
-                    (uuid >> 8) & 0xFF,  # xxxx
-                    0x00,
-                    0x00,
-                )
-            )  # 0000
+        elif isinstance(uuid, int):
+            if not 0 <= uuid <= 2**32:
+                raise ValueError("UUID integer value must be unsigned 16- or 32-bit")
+            if uuid <= 2**16:
+                self._size = 16
+            if uuid <= 2**32:
+                self._size = 32
+            self._uuid128 = self.standard_uuid128_from_uuid32(uuid)
+
         else:
             try:
                 uuid = memoryview(uuid)
@@ -112,9 +118,15 @@ class UUID:
 
     @property
     def uuid16(self) -> int:
-        if self.size == 128:
-            raise ValueError("This is a 128-bit UUID")
-        return (self._uuid128[13] << 8) | self._uuid128[12]
+        if self.size > 16:
+            raise ValueError(f"This is a {self.size}-bit UUID")
+        return int.from_bytes(self._uuid128[12:14], "little")
+
+    @property
+    def uuid32(self) -> int:
+        if self.size > 32:
+            raise ValueError(f"This is a {self.size}-bit UUID")
+        return int.from_bytes(self._uuid128[12:], "little")
 
     @property
     def uuid128(self) -> bytes:
@@ -130,14 +142,16 @@ class UUID:
             raise IndexError("Buffer offset too small")
         if self.size == 16:
             buffer[offset:byte_size] = self.uuid128[12:14]
+        elif self.size == 32:
+            buffer[offset:byte_size] = self.uuid128[12:]
         else:
             buffer[offset:byte_size] = self.uuid128
 
     @property
     def is_standard_uuid(self) -> bool:
-        """True if this is a standard 16-bit UUID (0000xxxx-0000-1000-8000-00805F9B34FB)
+        """True if this is a standard 16 or 32-bit UUID (xxxxxxxx-0000-1000-8000-00805F9B34FB)
         even if it's 128-bit."""
-        return self.size == 16 or (
+        return self.size == 16 or self.size == 32 or (
             self._uuid128[0:12] == _BASE_STANDARD_UUID[0:12]
             and self._uuid128[14:] == _BASE_STANDARD_UUID[14:]
         )
@@ -146,7 +160,9 @@ class UUID:
         if isinstance(other, UUID):
             if self.size == 16 and other.size == 16:
                 return self.uuid16 == other.uuid16
-            if self.size == 128 and other.size == 128:
+            elif self.size == 32 and other.size == 32:
+                return self.uuid32 == other.uuid32
+            elif self.size == 128 and other.size == 128:
                 return self.uuid128 == other.uuid128
 
         return False
@@ -154,6 +170,8 @@ class UUID:
     def __hash__(self):
         if self.size == 16:
             return hash(self.uuid16)
+        elif self.size == 32:
+            return hash(self.uuid32)
         return hash(self.uuid128)
 
     def __str__(self) -> str:
@@ -168,4 +186,6 @@ class UUID:
     def __repr__(self) -> str:
         if self.size == 16:
             return f"UUID({self.uuid16:#04x})"
+        elif self.size == 32:
+            return f"UUID({self.uuid32:#08x})"
         return f"UUID({self!s})"


### PR DESCRIPTION
Previously the library only supported 16-bit standard UUID, but the spec allows for 32-bit UUIDs as well. Encountering a 32-bit UUID caused the code to raise an exception. This fix adds support for 32-bit standard UUIDs.

Resolves #61 