### PR TITLE
Add missing requirements file to docs folder

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2021 Kattni Rembor for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+sphinx>=4.0.0


### PR DESCRIPTION
It looks like docs is still failing because I forgot to add the requirements file from #63.