### PR TITLE
Do not build non pypi assets: this is a host library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,49 +9,6 @@ on:
     types: [published]
 
 jobs:
-  upload-release-assets:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Dump GitHub context
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
-    - name: Translate Repo Name For Build Tools filename_prefix
-      id: repo-name
-      run: |
-        echo "repo-name=$(
-        echo ${{ github.repository }} |
-        awk -F '\/' '{ print tolower($2) }' |
-        tr '_' '-'
-        )" >> $GITHUB_OUTPUT
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
-    - name: Versions
-      run: |
-        python3 --version
-    - name: Checkout Current Repo
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-    - name: Checkout tools repo
-      uses: actions/checkout@v4
-      with:
-        repository: adafruit/actions-ci-circuitpython-libs
-        path: actions-ci
-    - name: Install deps
-      run: |
-        source actions-ci/install.sh
-    - name: Build assets
-      run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
-    - name: Upload Release Assets
-      uses: shogo82148/actions-upload-release-asset@v1
-      with:
-        asset_path: "bundles/*"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        upload_url: ${{ github.event.release.upload_url }}
-
   upload-pypi:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `yield from` added in #67 doesn't work on CircuitPython, but this library should not be being compiled with mpy-cross in any case. Remove making mpy-cross assets.

@justmobilize FYI